### PR TITLE
Add Docker support for serving site via Flask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies required by scientific Python stack
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . .
+
+EXPOSE 3000
+
+CMD ["python", "server.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask==3.0.3
+Flask-Cors==4.0.0
+numpy==1.26.4
+scipy==1.11.4
+pandas==2.2.2
+scikit-learn==1.4.2

--- a/server.py
+++ b/server.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from flask import Flask, jsonify, send_from_directory
+from flask_cors import CORS
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_ROOT = BASE_DIR
+
+app = Flask(__name__, static_folder=str(STATIC_ROOT), static_url_path="")
+CORS(app)
+
+
+@app.route("/")
+def serve_index():
+    """Return the main landing page for the portfolio site."""
+    return send_from_directory(app.static_folder, "index.html")
+
+
+@app.route("/<path:resource>")
+def serve_static(resource: str):
+    """Serve any other static asset in the repository.
+
+    If the resource does not exist, respond with a JSON 404 message so that
+    the client receives a meaningful response instead of the default HTML 404
+    from Flask.
+    """
+    file_path = Path(app.static_folder) / resource
+    if file_path.is_file():
+        # send_from_directory handles proper MIME types and caching headers
+        return send_from_directory(app.static_folder, resource)
+
+    return jsonify({"error": "Resource not found", "resource": resource}), 404
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 3000))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs dependencies and runs the Flask server
- capture Python package requirements in a requirements.txt for reproducible builds
- implement a lightweight Flask server that serves the static portfolio assets

## Testing
- python -m compileall server.py

------
https://chatgpt.com/codex/tasks/task_e_68f7d2c1d19c8333987814095fb4e62c